### PR TITLE
Disable stale HandleCommandDrop hook on plugin load

### DIFF
--- a/jRandomSkills - SRC Files/src/player/PlayerEvents.cs
+++ b/jRandomSkills - SRC Files/src/player/PlayerEvents.cs
@@ -40,8 +40,6 @@ namespace src.player
         public static readonly ConcurrentDictionary<uint, jSkill_SkillInfo> staticSkills = [];
         private static readonly object setLock = new();
 
-        private static readonly MemoryFunctionVoid<CBasePlayerPawn, CBasePlayerWeapon> DropWeaponFunc = new(GameData.GetSignature("CCSPlayerController_HandleCommandDrop"));
-
         public static void Load()
         {
             Instance.RegisterEventHandler<EventPlayerConnectFull>(PlayerConnectFull);
@@ -87,7 +85,9 @@ namespace src.player
             VirtualFunctions.CBaseTrigger_EndTouchFunc.Hook(OnTriggerExit, HookMode.Pre);
             VirtualFunctions.CCSPlayer_ItemServices_CanAcquireFunc.Hook(OnWeaponCanAcquire, HookMode.Pre);
 
-            DropWeaponFunc.Hook(WeaponDrop, HookMode.Pre);
+            // Disabled after CS2 updates started crashing Linux servers on player join.
+            // The hooked native signature is only used to block weapon drops for Iana clones.
+            // Keeping the plugin alive is safer than installing a stale global hook at load time.
         }
 
         private static jSkill_SkillInfo ChooseSkillByRarityAndMax(List<jSkill_SkillInfo> candidates, Dictionary<Skills, int> assignmentCounts, Config.GameModes gameMode)


### PR DESCRIPTION
Refs #29.

This is a small workaround for the Linux crash reported after recent CS2 updates. The plugin currently installs a global hook for `CCSPlayerController_HandleCommandDrop` during `Event.Load()`. If that gamedata signature is stale after a CS2 update, the hook can crash the dedicated server when a player fully connects.

The hook only appears to be used to block weapon drops while an Iana clone is active, so this PR disables that global hook rather than risking a startup/player-connect segmentation fault.

Side effect: Iana clones may no longer block weapon dropping. A fuller fix would be to update the Linux signature or replace this native hook with a safer API path.

Locally verified:
- `dotnet build` succeeds against `CounterStrikeSharp.API 1.0.368`
- rebuilt `jRandomSkills.dll` no longer contains `CCSPlayerController_HandleCommandDrop` / `DropWeaponFunc`