### PR TITLE
v1.2.2.b3

### DIFF
--- a/jRandomSkills - SRC Files/jRandomSkills.csproj
+++ b/jRandomSkills - SRC Files/jRandomSkills.csproj
@@ -12,9 +12,6 @@
     <ItemGroup>
         <Compile Remove="tools\**" />
         <None Remove="tools\**" />
-        <None Remove="src\command\Command.cs~RF4f34d1e7.TMP" />
-        <None Remove="src\player\PlayerOnTick.cs~RF38b6229.TMP" />
-        <None Remove="src\player\skills\RespWroga.cs~RF528d210.TMP" />
     </ItemGroup>
 
     <ItemGroup>
@@ -53,7 +50,7 @@
     <PropertyGroup>
         <SourceLangDir>$(MSBuildProjectDirectory)\src\lang</SourceLangDir>
         <ServerLangDir>$(MSBuildProjectDirectory)\..\jRandomSkills - Server Files\plugins\jRandomSkills\languages</ServerLangDir>
-        <SourceDLL>$(MSBuildProjectDirectory)\bin\Debug\net10.0</SourceDLL>
+        <SourceDLL>$(MSBuildProjectDirectory)\bin\$(Configuration)\$(TargetFramework)</SourceDLL>
         <ServerDLL>$(MSBuildProjectDirectory)\..\jRandomSkills - Server Files\plugins\jRandomSkills</ServerDLL>
         <SourceGamedataDir>$(MSBuildProjectDirectory)\src\gamedata</SourceGamedataDir>
 		<ServerGamedataDir>$(MSBuildProjectDirectory)\..\jRandomSkills - Server Files\gamedata</ServerGamedataDir>

--- a/jRandomSkills - SRC Files/src/command/Command.cs
+++ b/jRandomSkills - SRC Files/src/command/Command.cs
@@ -23,7 +23,7 @@ namespace src.command
         public static void Load()
         {
             config = Config.LoadedConfig;
-            if (config == null || config == null) return;
+            if (config == null) return;
 
             lock (setLock)
             {
@@ -200,7 +200,7 @@ namespace src.command
 
         private static void ChangeMap(CommandInfo command)
         {
-            string map = command.GetArg(1).ToLower();
+            string map = command.GetArg(1).ToLowerInvariant();
 
             if (string.IsNullOrEmpty(map))
             {
@@ -548,7 +548,7 @@ namespace src.command
                 if (langInfo.IsoCodes.Contains(newLangCode))
                     fileName = langInfo.FileName;
             if (Localization.HasTranslation(newLangCode))
-                fileName = newLangCode.ToLower();
+                fileName = newLangCode.ToLowerInvariant();
             Localization.ChangePlayerLanguage(player, fileName);
         }
 

--- a/jRandomSkills - SRC Files/src/jRandomSkills.cs
+++ b/jRandomSkills - SRC Files/src/jRandomSkills.cs
@@ -28,7 +28,7 @@ namespace src
         public override string ModuleName => "[CS2] [ jRandomSkills ]";
         public override string ModuleAuthor => "D3X, Juzlus";
         public override string ModuleDescription => "Plugin adds random skills every round for CS2 by D3X. Modified by Juzlus.";
-        public override string ModuleVersion => "1.2.2.b2";
+        public override string ModuleVersion => "1.2.2.b3";
 
         public override void Load(bool hotReload)
         {
@@ -78,43 +78,38 @@ namespace src
                 Debug.WriteToDebug($"Loaded: {skill.Skill}");
         }
 
+        private static readonly ConcurrentDictionary<(string Skill, string Method), MethodInfo?> _skillMethodCache = new();
+
         internal object? SkillAction(string skill, string methodName, object[]? param = null)
         {
             if (string.IsNullOrEmpty(skill))
                 return null;
 
-            string className = $"src.player.skills.{skill}";
-
-            Type? type = Type.GetType(className)
-                ?? Assembly.GetExecutingAssembly().GetType(className)
-                ?? AppDomain.CurrentDomain.GetAssemblies()
-                    .SelectMany(a =>
-                    {
-                        try { return a.GetTypes(); }
-                        catch (ReflectionTypeLoadException ex) { return ex.Types.Where(t => t!= null)!; }
-                        catch { return []; }
-                    })
-                    .FirstOrDefault(t => t != null && string.Equals(t.FullName, className, StringComparison.Ordinal));
-
-            if (type != null && typeof(ISkill).IsAssignableFrom(type))
+            var method = _skillMethodCache.GetOrAdd((skill, methodName), key =>
             {
-                MethodInfo? method = type.GetMethod(methodName, BindingFlags.Static | BindingFlags.Public);
-                return method?.Invoke(null, param);
-            }
-            else
-                Server.PrintToConsole($"Could not find or load {className}");
+                string className = $"src.player.skills.{key.Skill}";
 
-            return null;
-        }
+                Type? type = Type.GetType(className)
+                    ?? Assembly.GetExecutingAssembly().GetType(className)
+                    ?? AppDomain.CurrentDomain.GetAssemblies()
+                        .SelectMany(a =>
+                        {
+                            try { return a.GetTypes(); }
+                            catch (ReflectionTypeLoadException ex) { return ex.Types.Where(t => t != null)!; }
+                            catch { return []; }
+                        })
+                        .FirstOrDefault(t => t != null && string.Equals(t.FullName, className, StringComparison.Ordinal));
 
-        internal void RegisterListener<T>(Action onTick, HookMode pre)
-        {
-            throw new NotImplementedException();
-        }
+                if (type == null || !typeof(ISkill).IsAssignableFrom(type))
+                {
+                    Server.PrintToConsole($"Could not find or load {className}");
+                    return null;
+                }
 
-        internal void RegisterListener<T>(Action<object, object> value, HookMode pre)
-        {
-            throw new NotImplementedException();
+                return type.GetMethod(key.Method, BindingFlags.Static | BindingFlags.Public);
+            });
+
+            return method?.Invoke(null, param);
         }
 
         internal new void AddCommand(string name, string description, CommandInfo.CommandCallback handler)
@@ -328,10 +323,7 @@ namespace src
         public string Color { get; set; } = color;
         public bool Display { get; } = display;
 
-        public static implicit operator Skills(jSkill_SkillInfo v)
-        {
-            throw new NotImplementedException();
-        }
+        public static implicit operator Skills(jSkill_SkillInfo v) => v?.Skill ?? Skills.None;
     }
 
     public static class SkillData

--- a/jRandomSkills - SRC Files/src/lang/tr.json
+++ b/jRandomSkills - SRC Files/src/lang/tr.json
@@ -24,6 +24,7 @@
   "areareaper_select_info": "Kapatılacak bomba alanını seç:",
   "areareaper_site_disabled": "{0} alanı mühürlendi - artık buraya bomba kurulamaz!",
   "areareaper_used_info": "Yeteneğini zaten kullandın, açgözlülük yapma",
+  "areareaper_teammates_info": "{0} Bölgesi bomba kurmaya kapatıldı.",
   "areareaper_bombsite_disabled": "Bu bomba alanı kullanıma kapatıldı!",
 
   "armored": "Zırhlı",
@@ -62,6 +63,7 @@
   "carefulbullets": "Dikkatli Mermiler",
   "carefulbullets_desc": "Düşman mermi kaçırırsa hasar alır",
   "carefulbullets_enemy_info": "Mermi kaçırmak canını yakacak",
+  "carefulbullets_disable_info": "Artık mermi kaçırmak can yakmayacak.",
   "carefulbullets_player_info": "'{0}' artık mermi sıkarken iki kere düşünecek",
   "carefulbullets_select_info": "İsabetsiz atışların hasar vereceği oyuncu:",
 
@@ -85,6 +87,7 @@
   "darkness": "Karanlık",
   "darkness_desc": "Bir düşmanın ekranını karart",
   "darkness_enemy_info": "Işıklar sönsün",
+  "darkness_disable_info": "Işıklar geldi.",
   "darkness_player_info": "'{0}' isimli oyuncunun dünyasını kararttın",
   "darkness_select_info": "Karanlık bir oyuncuyu seç:",
 
@@ -97,6 +100,7 @@
   "deaf": "Sağır",
   "deaf_desc": "Bir düşmanın kulağını kapat ve sesleri duymaz hale getir",
   "deaf_enemy_info": "Kulaklıkların tıkandı",
+  "deaf_disable_info": "Kulakların açıldı.",
   "deaf_player_info": "'{0}' isimli oyuncu için sesler kapatıldı.",
   "deaf_select_info": "Sağır bir oyuncuyu seç:",
 
@@ -167,6 +171,7 @@
   "glitch": "Glitç",
   "glitch_desc": "Seçilen bir düşmanın radarını kapatır",
   "glitch_enemy_info": "Radarın kapandı",
+  "glitch_disable_info": "Radarın açıldı",
   "glitch_player_info": "'{0}' isimli oyuncunun radarı devre dışı bırakıldı.",
   "glitch_select_info": "Radarı kapatılacak oyuncuyu seç:",
 
@@ -218,6 +223,7 @@
   "jammer": "Sinyal Kesici",
   "jammer_desc": "Bir oyuncunun nişangahını (crosshair) kapatmak için seç",
   "jammer_enemy_info": "Nişangahın kapatıldı.",
+  "jammer_disable_info": "Nişangahın açıldı",
   "jammer_player_info": "'{0}' isimli oyuncunun nişangahı kapatıldı.",
   "jammer_select_info": "Nişangahı kapatılacak oyuncuyu seç:",
 
@@ -230,6 +236,7 @@
   "jumpban": "Bacaksız",
   "jumpban_desc": "Zıplayamayacak bir oyuncu seç",
   "jumpban_enemy_info": "Bacakların kesildi",
+  "jumpban_disable_info": "Bacaklarına kavuştun",
   "jumpban_player_info": "'{0}' artık zıplayamaz.",
   "jumpban_select_info": "Zıplaması yasaklanacak oyuncu:",
 
@@ -260,6 +267,7 @@
   "magnifier": "Büyüteç",
   "magnifier_desc": "Düşmanın ekranını yakınlaştırarak görüş alanını daraltır",
   "magnifier_enemy_info": "Görüşün bozuldu!",
+  "magnifier_disable_info": "Görüşün düzeldi",
   "magnifier_player_info": "'{0}' isimli oyuncunun ekranı yakınlaştırıldı.",
   "magnifier_select_info": "Ekranı büyütülecek oyuncuyu seç:",
 
@@ -321,12 +329,14 @@
   "poison": "Zehir",
   "poison_desc": "Birkaç saniyede bir hasar alacak bir oyuncu seç",
   "poison_enemy_info": "Zehirlendin.",
+  "poison_disable_info": "Zehire bağışıklık kazandın",
   "poison_player_info": "'{0}' isimli oyuncu zehirlendi.",
   "poison_select_info": "Zehirlenecek oyuncuyu seç:",
 
   "primaryban": "Tüfek Yasak",
   "primaryban_desc": "Tüfek kullanamayacak bir oyuncu seç",
   "primaryban_enemy_info": "Tüfek kullanmayı unuttun",
+  "primaryban_disable_info": "Tüfek kullanabilirsin",
   "primaryban_player_info": "'{0}' artık tüfek kullanamaz.",
   "primaryban_select_info": "Tüfek kullanımı yasaklanacak oyuncu:",
 
@@ -457,6 +467,7 @@
   "wildthrow": "Unutkan Bombacı",
   "wildthrow_desc": "El bombası atmakta zorluk çekecek bir oyuncu seçin",
   "wildthrow_player_info": "'{0}' adlı oyuncu tüm taktiklerini unuttu",
+  "wildthrow_enemy_info": "Bomba atarken çok heyecanlanıyorsun.",
   "wildthrow_select_info": "Bir oyuncu seçin:",
 
   "zeus": "Zeus",

--- a/jRandomSkills - SRC Files/src/player/PlayerEvents.cs
+++ b/jRandomSkills - SRC Files/src/player/PlayerEvents.cs
@@ -137,17 +137,21 @@ namespace src.player
             return candidates[Random.Shared.Next(candidates.Count)];
         }
 
+        private static void DispatchToActiveSkills(string methodName, params object[] args)
+        {
+            var seen = new HashSet<Skills>();
+            foreach (var p in Instance.SkillPlayer)
+            {
+                if (p.IsDrawing || !seen.Add(p.Skill)) continue;
+                Instance.SkillAction(p.Skill.ToString(), methodName, args);
+            }
+        }
+
         private static HookResult PlayerMakeSound(UserMessage um)
         {
             lock (setLock)
             {
-                var activeSkills = Instance.SkillPlayer
-                    .Where(p => !p.IsDrawing)
-                    .Select(p => p.Skill.ToString())
-                    .Distinct();
-
-                foreach (string skillName in activeSkills)
-                    Instance.SkillAction(skillName, "PlayerMakeSound", [um]);
+                DispatchToActiveSkills("PlayerMakeSound", um);
                 return HookResult.Continue;
             }
         }
@@ -156,13 +160,7 @@ namespace src.player
         {
             lock (setLock)
             {
-                var activeSkills = Instance.SkillPlayer
-                    .Where(p => !p.IsDrawing)
-                    .Select(p => p.Skill.ToString())
-                    .Distinct();
-
-                foreach (string skillName in activeSkills)
-                    Instance.SkillAction(skillName, "WeaponFire", [@event]);
+                DispatchToActiveSkills("WeaponFire", @event);
                 return HookResult.Continue;
             }
         }
@@ -171,13 +169,7 @@ namespace src.player
         {
             lock (setLock)
             {
-                var activeSkills = Instance.SkillPlayer
-                    .Where(p => !p.IsDrawing)
-                    .Select(p => p.Skill.ToString())
-                    .Distinct();
-
-                foreach (string skillName in activeSkills)
-                    Instance.SkillAction(skillName, "WeaponEquip", [@event]);
+                DispatchToActiveSkills("WeaponEquip", @event);
                 return HookResult.Continue;
             }
         }
@@ -186,13 +178,7 @@ namespace src.player
         {
             lock (setLock)
             {
-                var activeSkills = Instance.SkillPlayer
-                    .Where(p => !p.IsDrawing)
-                    .Select(p => p.Skill.ToString())
-                    .Distinct();
-
-                foreach (string skillName in activeSkills)
-                    Instance.SkillAction(skillName, "WeaponPickup", [@event]);
+                DispatchToActiveSkills("WeaponPickup", @event);
                 return HookResult.Continue;
             }
         }
@@ -201,13 +187,7 @@ namespace src.player
         {
             lock (setLock)
             {
-                var activeSkills = Instance.SkillPlayer
-                    .Where(p => !p.IsDrawing)
-                    .Select(p => p.Skill.ToString())
-                    .Distinct();
-
-                foreach (string skillName in activeSkills)
-                    Instance.SkillAction(skillName, "WeaponReload", [@event]);
+                DispatchToActiveSkills("WeaponReload", @event);
                 return HookResult.Continue;
             }
         }
@@ -216,13 +196,7 @@ namespace src.player
         {
             lock (setLock)
             {
-                var activeSkills = Instance.SkillPlayer
-                    .Where(p => !p.IsDrawing)
-                    .Select(p => p.Skill.ToString())
-                    .Distinct();
-
-                foreach (string skillName in activeSkills)
-                    Instance.SkillAction(skillName, "GrenadeThrown", [@event]);
+                DispatchToActiveSkills("GrenadeThrown", @event);
                 return HookResult.Continue;
             }
         }
@@ -231,13 +205,7 @@ namespace src.player
         {
             lock (setLock)
             {
-                var activeSkills = Instance.SkillPlayer
-                    .Where(p => !p.IsDrawing)
-                    .Select(p => p.Skill.ToString())
-                    .Distinct();
-
-                foreach (string skillName in activeSkills)
-                    Instance.SkillAction(skillName, "BombBeginplant", [@event]);
+                DispatchToActiveSkills("BombBeginplant", @event);
                 return HookResult.Continue;
             }
         }
@@ -246,13 +214,7 @@ namespace src.player
         {
             lock (setLock)
             {
-                var activeSkills = Instance.SkillPlayer
-                    .Where(p => !p.IsDrawing)
-                    .Select(p => p.Skill.ToString())
-                    .Distinct();
-
-                foreach (string skillName in activeSkills)
-                    Instance.SkillAction(skillName, "BombAbortplant", [@event]);
+                DispatchToActiveSkills("BombAbortplant", @event);
                 return HookResult.Continue;
             }
         }
@@ -261,13 +223,7 @@ namespace src.player
         {
             lock (setLock)
             {
-                var activeSkills = Instance.SkillPlayer
-                    .Where(p => !p.IsDrawing)
-                    .Select(p => p.Skill.ToString())
-                    .Distinct();
-
-                foreach (string skillName in activeSkills)
-                    Instance.SkillAction(skillName, "BombPlanted", [@event]);
+                DispatchToActiveSkills("BombPlanted", @event);
                 return HookResult.Continue;
             }
         }
@@ -276,13 +232,7 @@ namespace src.player
         {
             lock (setLock)
             {
-                var activeSkills = Instance.SkillPlayer
-                    .Where(p => !p.IsDrawing)
-                    .Select(p => p.Skill.ToString())
-                    .Distinct();
-
-                foreach (string skillName in activeSkills)
-                    Instance.SkillAction(skillName, "BombBegindefuse", [@event]);
+                DispatchToActiveSkills("BombBegindefuse", @event);
                 return HookResult.Continue;
             }
         }
@@ -291,13 +241,7 @@ namespace src.player
         {
             lock (setLock)
             {
-                var activeSkills = Instance.SkillPlayer
-                    .Where(p => !p.IsDrawing)
-                    .Select(p => p.Skill.ToString())
-                    .Distinct();
-
-                foreach (string skillName in activeSkills)
-                    Instance.SkillAction(skillName, "DecoyStarted", [@event]);
+                DispatchToActiveSkills("DecoyStarted", @event);
                 return HookResult.Continue;
             }
         }
@@ -306,13 +250,7 @@ namespace src.player
         {
             lock (setLock)
             {
-                var activeSkills = Instance.SkillPlayer
-                    .Where(p => !p.IsDrawing)
-                    .Select(p => p.Skill.ToString())
-                    .Distinct();
-
-                foreach (string skillName in activeSkills)
-                    Instance.SkillAction(skillName, "DecoyDetonate", [@event]);
+                DispatchToActiveSkills("DecoyDetonate", @event);
                 return HookResult.Continue;
             }
         }
@@ -321,13 +259,7 @@ namespace src.player
         {
             lock (setLock)
             {
-                var activeSkills = Instance.SkillPlayer
-                    .Where(p => !p.IsDrawing)
-                    .Select(p => p.Skill.ToString())
-                    .Distinct();
-
-                foreach (string skillName in activeSkills)
-                    Instance.SkillAction(skillName, "SmokegrenadeDetonate", [@event]);
+                DispatchToActiveSkills("SmokegrenadeDetonate", @event);
                 return HookResult.Continue;
             }
         }
@@ -336,13 +268,7 @@ namespace src.player
         {
             lock (setLock)
             {
-                var activeSkills = Instance.SkillPlayer
-                    .Where(p => !p.IsDrawing)
-                    .Select(p => p.Skill.ToString())
-                    .Distinct();
-
-                foreach (string skillName in activeSkills)
-                    Instance.SkillAction(skillName, "SmokegrenadeExpired", [@event]);
+                DispatchToActiveSkills("SmokegrenadeExpired", @event);
                 return HookResult.Continue;
             }
         }
@@ -351,13 +277,7 @@ namespace src.player
         {
             lock (setLock)
             {
-                var activeSkills = Instance.SkillPlayer
-                    .Where(p => !p.IsDrawing)
-                    .Select(p => p.Skill.ToString())
-                    .Distinct();
-
-                foreach (string skillName in activeSkills)
-                    Instance.SkillAction(skillName, "PlayerHurt", [@event]);
+                DispatchToActiveSkills("PlayerHurt", @event);
                 return HookResult.Continue;
             }
         }
@@ -366,13 +286,7 @@ namespace src.player
         {
             lock (setLock)
             {
-                var activeSkills = Instance.SkillPlayer
-                    .Where(p => !p.IsDrawing)
-                    .Select(p => p.Skill.ToString())
-                    .Distinct();
-
-                foreach (string skillName in activeSkills)
-                    Instance.SkillAction(skillName, "PlayerJump", [@event]);
+                DispatchToActiveSkills("PlayerJump", @event);
                 return HookResult.Continue;
             }
         }
@@ -381,13 +295,7 @@ namespace src.player
         {
             lock (setLock)
             {
-                var activeSkills = Instance.SkillPlayer
-                    .Where(p => !p.IsDrawing)
-                    .Select(p => p.Skill.ToString())
-                    .Distinct();
-
-                foreach (string skillName in activeSkills)
-                    Instance.SkillAction(skillName, "PlayerBlind", [@event]);
+                DispatchToActiveSkills("PlayerBlind", @event);
                 return HookResult.Continue;
             }
         }
@@ -396,15 +304,10 @@ namespace src.player
         {
             lock (setLock)
             {
-                var activeSkills = Instance.SkillPlayer
-                    .Where(p => !p.IsDrawing)
-                    .Select(p => p.Skill.ToString())
-                    .Distinct();
+                DispatchToActiveSkills("OnTakeDamage", h);
 
-                foreach (string skillName in activeSkills)
-                    Instance.SkillAction(skillName, "OnTakeDamage", [h]);
-                
-                if (Fortnite.skillInThisRound == true && !activeSkills.Any(s => s == "Fortnite"))
+                if (Fortnite.skillInThisRound == true &&
+                    !Instance.SkillPlayer.Any(p => !p.IsDrawing && p.Skill == Skills.Fortnite))
                     Instance.SkillAction("Fortnite", "OnTakeDamage", [h]);
 
                 return HookResult.Continue;
@@ -418,13 +321,7 @@ namespace src.player
                 CBaseTrigger trigger = hook.GetParam<CBaseTrigger>(0);
                 CBaseEntity entity = hook.GetParam<CBaseEntity>(1);
 
-                var activeSkills = Instance.SkillPlayer
-                    .Where(p => !p.IsDrawing)
-                    .Select(p => p.Skill.ToString())
-                    .Distinct();
-
-                foreach (string skillName in activeSkills)
-                    Instance.SkillAction(skillName, "OnTriggerEnter", [trigger, entity]);
+                DispatchToActiveSkills("OnTriggerEnter", trigger, entity);
                 return HookResult.Continue;
             }
         }
@@ -436,13 +333,7 @@ namespace src.player
                 CBaseTrigger trigger = hook.GetParam<CBaseTrigger>(0);
                 CBaseEntity entity = hook.GetParam<CBaseEntity>(1);
 
-                var activeSkills = Instance.SkillPlayer
-                    .Where(p => !p.IsDrawing)
-                    .Select(p => p.Skill.ToString())
-                    .Distinct();
-
-                foreach (string skillName in activeSkills)
-                    Instance.SkillAction(skillName, "OnTriggerExit", [trigger, entity]);
+                DispatchToActiveSkills("OnTriggerExit", trigger, entity);
                 return HookResult.Continue;
             }
         }
@@ -544,6 +435,13 @@ namespace src.player
 
                 if (player.IsBot && !Config.LoadedConfig.EnableBotSkills)
                     return;
+
+                var existing = Instance.SkillPlayer.FirstOrDefault(p => p.PlayerIndex == player.Index);
+                if (existing != null)
+                {
+                    PlayerManager.Register(existing);
+                    return;
+                }
 
                 var playerInfo = new jSkill_PlayerInfo
                 {
@@ -699,7 +597,6 @@ namespace src.player
                     if (playerInfo == null) continue;
 
                     Instance.SkillAction(playerInfo.Skill.ToString(), "DisableSkill", [player]);
-                    Instance.SkillAction(playerInfo.Skill.ToString(), "NewRound");
 
                     playerInfo.Skill = noneSkill.Skill;
                     playerInfo.SpecialSkill = noneSkill.Skill;
@@ -709,6 +606,9 @@ namespace src.player
 
                     RestorePlayer(player);
                 }
+
+                foreach (var skill in SkillData.Skills)
+                    Instance.SkillAction(skill.Skill.ToString(), "NewRound");
             }
         }
 
@@ -733,23 +633,24 @@ namespace src.player
             lock (setLock)
             {
                 isTransmitRegistered = false;
-
-                Instance.AddTimer(.1f, () => {
-                    DisableAll();
-                    ConVar.Find("sv_legacy_jump")?.SetValue("1");
-
-                }, CounterStrikeSharp.API.Modules.Timers.TimerFlags.STOP_ON_MAPCHANGE);
-                
                 Instance.RemoveListener<CheckTransmit>(CheckTransmit);
-                
+
+                Fortnite.skillInThisRound = false;
+                EntityManager.DestroyAllTracked();
+                foreach (var skill in SkillData.Skills)
+                    Instance.SkillAction(skill.Skill.ToString(), "NewRound");
+
                 playersSkills.Clear();
                 staticSkills.Clear();
-                
+
                 ctSkill = noneSkill;
                 tSkill = noneSkill;
                 allSkill = noneSkill;
-                
+
+                Instance.SkillPlayer.Clear();
                 PlayerManager.Clear();
+
+                ConVar.Find("sv_legacy_jump")?.SetValue("1");
             }
         }
 
@@ -803,13 +704,7 @@ namespace src.player
         {
             lock (setLock)
             {
-                var activeSkills = Instance.SkillPlayer
-                    .Where(p => !p.IsDrawing)
-                    .Select(p => p.Skill.ToString())
-                    .Distinct();
-
-                foreach (string skillName in activeSkills)
-                    Instance.SkillAction(skillName, "PlayerDeath", [@event]);
+                DispatchToActiveSkills("PlayerDeath", @event);
 
                 var victim = PlayerManager.GetPlayerEvent(@event.Userid);
                 var attacker = PlayerManager.GetPlayerEvent(@event.Attacker);
@@ -848,10 +743,12 @@ namespace src.player
                 string? button = Config.LoadedConfig.AlternativeSkillButton;
                 if (string.IsNullOrEmpty(button) || button.Length < 2) return;
 
-                string buttonName = $"{char.ToUpper(button[0])}{button[1..].ToLower()}";
+                string buttonName = $"{char.ToUpperInvariant(button[0])}{button[1..].ToLowerInvariant()}";
                 if (!Enum.TryParse<PlayerButtons>(buttonName, out var skillButton)) return;
 
                 if ((pressed & skillButton) == 0) return;
+
+                if (SkillUtils.HasMenu(player)) return;
 
                 var playerInfo = PlayerManager.GetPlayerByIndex(player!.Index);
                 if (playerInfo == null || playerInfo.IsDrawing) return;
@@ -893,13 +790,7 @@ namespace src.player
         {
             lock (setLock)
             {
-                var activeSkills = Instance.SkillPlayer
-                    .Where(p => !p.IsDrawing)
-                    .Select(p => p.Skill.ToString())
-                    .Distinct();
-
-                foreach (string skillName in activeSkills)
-                    Instance.SkillAction(skillName, "OnEntitySpawned", [entity]);
+                DispatchToActiveSkills("OnEntitySpawned", entity);
             }
         }
 
@@ -907,13 +798,7 @@ namespace src.player
         {
             lock (setLock)
             {
-                var activeSkills = Instance.SkillPlayer
-                    .Where(p => !p.IsDrawing)
-                    .Select(p => p.Skill.ToString())
-                    .Distinct();
-
-                foreach (string skillName in activeSkills)
-                    Instance.SkillAction(skillName, "BulletImpact", [@event]);
+                DispatchToActiveSkills("BulletImpact", @event);
                 return HookResult.Continue;
             }
         }
@@ -1190,6 +1075,7 @@ namespace src.player
                     }
                 }
 
+                Instance?.SkillAction(skillPlayer.Skill.ToString(), "DisableSkill", [player]);
                 skillPlayer.Skill = randomSkill.Skill;
                 skillPlayer.SpecialSkill = Skills.None;
 
@@ -1221,13 +1107,7 @@ namespace src.player
         {
             lock (setLock)
             {
-                var activeSkills = Instance.SkillPlayer
-                    .Where(p => !p.IsDrawing)
-                    .Select(p => p.Skill.ToString())
-                    .Distinct();
-
-                foreach (string skillName in activeSkills)
-                    Instance.SkillAction(skillName, "CheckTransmit", [infoList]);
+                DispatchToActiveSkills("CheckTransmit", infoList);
             }
         }
 

--- a/jRandomSkills - SRC Files/src/player/skills/AreaReaper.cs
+++ b/jRandomSkills - SRC Files/src/player/skills/AreaReaper.cs
@@ -60,6 +60,10 @@ namespace src.player.skills
                     playerInfo.SkillUsed = true;
 
                     playersToTarget[player.Index] = targetSite.Index;
+
+                    string siteLetter = site == 0 ? "A" : "B";
+                    foreach (var ct in Utilities.GetPlayers().Where(p => p != null && p.IsValid && !p.IsHLTV && p.Team == CsTeam.CounterTerrorist))
+                        ct.PrintToChat($" {ChatColors.Green}" + ct.GetTranslation("areareaper_teammates_info", siteLetter));
                 }
             }
         }

--- a/jRandomSkills - SRC Files/src/player/skills/CarefulBullets.cs
+++ b/jRandomSkills - SRC Files/src/player/skills/CarefulBullets.cs
@@ -171,6 +171,10 @@ namespace src.player.skills
                 targetPlayers.TryRemove(targetIndex, out _);
                 lastShot.TryRemove(targetIndex, out _);
                 hitPlayer.TryRemove(targetIndex, out _);
+
+                var target = Utilities.GetPlayerFromIndex((int)targetIndex);
+                if (target != null && target.IsValid && target.PawnIsAlive && !SkillUtils.IsFreezeTime())
+                    target.PrintToChat($" {ChatColors.Green}" + target.GetTranslation("carefulbullets_disable_info"));
             }
 
             SkillUtils.CloseMenu(player);

--- a/jRandomSkills - SRC Files/src/player/skills/Darkness.cs
+++ b/jRandomSkills - SRC Files/src/player/skills/Darkness.cs
@@ -106,7 +106,11 @@ namespace src.player.skills
                 {
                     var target = Utilities.GetPlayerFromIndex((int)targetIndex);
                     if (target != null && target.IsValid)
+                    {
                         SetUpPostProcessing(target, true);
+                        if (target.PawnIsAlive && !SkillUtils.IsFreezeTime())
+                            target.PrintToChat($" {ChatColors.Green}" + target.GetTranslation("darkness_disable_info"));
+                    }
                     playersInDark.TryRemove(targetIndex, out _);
                 }
 

--- a/jRandomSkills - SRC Files/src/player/skills/Deaf.cs
+++ b/jRandomSkills - SRC Files/src/player/skills/Deaf.cs
@@ -109,7 +109,13 @@ namespace src.player.skills
         public static void DisableSkill(CCSPlayerController player)
         {
             if (playersToTarget.TryRemove(player.Index, out uint targetIndex))
+            {
                 deafPlayers.TryRemove(targetIndex, out _);
+
+                var target = Utilities.GetPlayerFromIndex((int)targetIndex);
+                if (target != null && target.IsValid && target.PawnIsAlive && !SkillUtils.IsFreezeTime())
+                    target.PrintToChat($" {ChatColors.Green}" + target.GetTranslation("deaf_disable_info"));
+            }
 
             SkillUtils.CloseMenu(player);
         }

--- a/jRandomSkills - SRC Files/src/player/skills/Glitch.cs
+++ b/jRandomSkills - SRC Files/src/player/skills/Glitch.cs
@@ -104,7 +104,11 @@ namespace src.player.skills
             {
                 var target = Utilities.GetPlayerFromIndex((int)targetIndex);
                 if (target != null && target.IsValid)
+                {
                     target.ReplicateConVar("sv_disable_radar", "0");
+                    if (target.PawnIsAlive && !SkillUtils.IsFreezeTime())
+                        target.PrintToChat($" {ChatColors.Green}" + target.GetTranslation("glitch_disable_info"));
+                }
                 glitchedPlayers.TryRemove(targetIndex, out _);
             }
 

--- a/jRandomSkills - SRC Files/src/player/skills/Jammer.cs
+++ b/jRandomSkills - SRC Files/src/player/skills/Jammer.cs
@@ -117,7 +117,11 @@ namespace src.player.skills
             {
                 var target = Utilities.GetPlayerFromIndex((int)targetIndex);
                 if (target != null && target.IsValid)
+                {
                     SetCrosshair(target, true);
+                    if (target.PawnIsAlive && !SkillUtils.IsFreezeTime())
+                        target.PrintToChat($" {ChatColors.Green}" + target.GetTranslation("jammer_disable_info"));
+                }
                 jammedPlayers.TryRemove(targetIndex, out _);
             }
 

--- a/jRandomSkills - SRC Files/src/player/skills/JumpBan.cs
+++ b/jRandomSkills - SRC Files/src/player/skills/JumpBan.cs
@@ -117,7 +117,13 @@ namespace src.player.skills
                 return;
 
             if (playersToTarget.TryRemove(player.Index, out uint targetIndex))
+            {
                 bannedPlayers.TryRemove(targetIndex, out _);
+
+                var target = Utilities.GetPlayerFromIndex((int)targetIndex);
+                if (target != null && target.IsValid && target.PawnIsAlive && !SkillUtils.IsFreezeTime())
+                    target.PrintToChat($" {ChatColors.Green}" + target.GetTranslation("jumpban_disable_info"));
+            }
 
             SkillUtils.CloseMenu(player);
         }

--- a/jRandomSkills - SRC Files/src/player/skills/Magnifier.cs
+++ b/jRandomSkills - SRC Files/src/player/skills/Magnifier.cs
@@ -106,11 +106,15 @@ namespace src.player.skills
             {
                 var target = Utilities.GetPlayerFromIndex((int)targetIndex);
                 if (target != null && target.IsValid)
+                {
                     if (playersFOV.TryGetValue(targetIndex, out uint fov))
                     {
                         target.DesiredFOV = fov;
                         Utilities.SetStateChanged(target, "CBasePlayerController", "m_iDesiredFOV");
                     }
+                    if (target.PawnIsAlive && !SkillUtils.IsFreezeTime())
+                        target.PrintToChat($" {ChatColors.Green}" + target.GetTranslation("magnifier_disable_info"));
+                }
                 playersFOV.TryRemove(targetIndex, out _);
             }
 

--- a/jRandomSkills - SRC Files/src/player/skills/Poison.cs
+++ b/jRandomSkills - SRC Files/src/player/skills/Poison.cs
@@ -107,7 +107,13 @@ namespace src.player.skills
         public static void DisableSkill(CCSPlayerController player)
         {
             if (playersToTarget.TryRemove(player.Index, out uint targetIndex))
+            {
                 poisonedPlayers.TryRemove(targetIndex, out _);
+
+                var target = Utilities.GetPlayerFromIndex((int)targetIndex);
+                if (target != null && target.IsValid && target.PawnIsAlive && !SkillUtils.IsFreezeTime())
+                    target.PrintToChat($" {ChatColors.Green}" + target.GetTranslation("poison_disable_info"));
+            }
 
             SkillUtils.CloseMenu(player);
         }

--- a/jRandomSkills - SRC Files/src/player/skills/PrimaryBan.cs
+++ b/jRandomSkills - SRC Files/src/player/skills/PrimaryBan.cs
@@ -120,7 +120,13 @@ namespace src.player.skills
         public static void DisableSkill(CCSPlayerController player)
         {
             if (playersToTarget.TryRemove(player.Index, out uint targetIndex))
+            {
                 bannedPlayers.TryRemove(targetIndex, out _);
+
+                var target = Utilities.GetPlayerFromIndex((int)targetIndex);
+                if (target != null && target.IsValid && target.PawnIsAlive && !SkillUtils.IsFreezeTime())
+                    target.PrintToChat($" {ChatColors.Green}" + target.GetTranslation("primaryban_disable_info"));
+            }
 
             SkillUtils.CloseMenu(player);
         }

--- a/jRandomSkills - SRC Files/src/player/skills/Wallhack.cs
+++ b/jRandomSkills - SRC Files/src/player/skills/Wallhack.cs
@@ -112,7 +112,10 @@ namespace src.player.skills
             playersInAction.TryRemove(player.Index, out _);
 
             if (playersInAction.IsEmpty)
+            {
                 NewRound();
+                return;
+            }
 
             SkillUtils.ForceFullUpdateToAll();
         }

--- a/jRandomSkills - SRC Files/src/player/skills/WildThrow.cs
+++ b/jRandomSkills - SRC Files/src/player/skills/WildThrow.cs
@@ -121,6 +121,7 @@ namespace src.player.skills
 
             playerInfo.SkillUsed = true;
             player.PrintToChat($" {ChatColors.Green}" + player.GetTranslation("wildthrow_player_info", enemy.PlayerName));
+            enemy.PrintToChat($" {ChatColors.Red}" + enemy.GetTranslation("wildthrow_enemy_info"));
         }
 
         public static void OnEntitySpawned(CEntityInstance @event)

--- a/jRandomSkills - SRC Files/src/utils/Config.cs
+++ b/jRandomSkills - SRC Files/src/utils/Config.cs
@@ -71,9 +71,6 @@ namespace src.utils
 
         public class SettingsModel
         {
-            [DisplayName("Game Mode")]
-            [Description("TESTfafw..")]
-            [Range(0, 5)]
             public string ConfigName { get; set; }
             public int GameMode { get; set; }
             public bool YourSkillChatInfo { get; set; }

--- a/jRandomSkills - SRC Files/src/utils/Localization.cs
+++ b/jRandomSkills - SRC Files/src/utils/Localization.cs
@@ -50,7 +50,7 @@ namespace src.utils
             if (!File.Exists(langPath))
                 return;
 
-            var code = Path.GetFileNameWithoutExtension(langPath).ToLower();
+            var code = Path.GetFileNameWithoutExtension(langPath).ToLowerInvariant();
             var jsonText = File.ReadAllText(langPath);
             var translations = JsonConvert.DeserializeObject<ConcurrentDictionary<string, string>>(jsonText);
 
@@ -60,7 +60,7 @@ namespace src.utils
 
         public static bool HasTranslation(string code)
         {
-            return _translations.ContainsKey(code.ToLower());
+            return _translations.ContainsKey(code.ToLowerInvariant());
         }
 
         public static string GetSkillName(this CCSPlayerController player, Skills skill, float? chance = null)
@@ -68,7 +68,7 @@ namespace src.utils
             string langCode = GetLangCode(player);
             if (chance == null)
             {
-                var translation = GetTranslation(skill.ToString().ToLower(), langCode);
+                var translation = GetTranslation(skill.ToString().ToLowerInvariant(), langCode);
                 if (!translation.Contains("{0}"))
                     return translation;
                 
@@ -81,7 +81,7 @@ namespace src.utils
             }
 
             var value = Math.Round((double)(chance ?? 1), 2);
-            var skillNameText = GetTranslation(skill.ToString().ToLower(), langCode, player, value);
+            var skillNameText = GetTranslation(skill.ToString().ToLowerInvariant(), langCode, player, value);
             if (skillNameText.Contains('%')) skillNameText = skillNameText.Replace(value.ToString(), Math.Round(value * 100, 0).ToString());
             return skillNameText;
         }
@@ -91,7 +91,7 @@ namespace src.utils
             string langCode = GetLangCode(player);
             if (chance == null)
             {
-                var translation = GetTranslation($"{skill.ToString().ToLower()}_desc", langCode);
+                var translation = GetTranslation($"{skill.ToString().ToLowerInvariant()}_desc", langCode);
                 if (!translation.Contains("{0}"))
                     return translation;
 
@@ -103,12 +103,12 @@ namespace src.utils
                 return string.Join(' ', filtered);
             }
 
-            var skillName = $"{skill.ToString().ToLower()}_desc2";
+            var skillName = $"{skill.ToString().ToLowerInvariant()}_desc2";
             var value = Math.Round((double)(chance ?? 1), 2);
             var desc2 = GetTranslation(skillName, langCode, player, value);
 
             var skilLDescription = desc2 == skillName
-                ? player.GetTranslation($"{skill.ToString().ToLower()}_desc")
+                ? player.GetTranslation($"{skill.ToString().ToLowerInvariant()}_desc")
                 : desc2.Contains('%') ? desc2.Replace(value.ToString(), Math.Round(value * 100, 0).ToString()) : desc2;
             return skilLDescription;
         }

--- a/jRandomSkills - SRC Files/src/utils/RayTrace.cs
+++ b/jRandomSkills - SRC Files/src/utils/RayTrace.cs
@@ -28,7 +28,9 @@ namespace src.utils
                 playerPawn.CBodyComponent?.SceneNode == null)
                 return null;
 
-            var rayTrace = RayTraceInterface.Get();
+            CRayTraceInterface? rayTrace;
+            try { rayTrace = RayTraceInterface.Get(); }
+            catch { return null; }
             if (rayTrace == null)
                 return null;
 
@@ -111,7 +113,9 @@ namespace src.utils
                 playerPawn.CBodyComponent?.SceneNode == null)
                 return null;
 
-            var rayTrace = RayTraceInterface.Get();
+            CRayTraceInterface? rayTrace;
+            try { rayTrace = RayTraceInterface.Get(); }
+            catch { return null; }
             if (rayTrace == null)
                 return null;
 

--- a/jRandomSkills - SRC Files/src/utils/SkillUtils.cs
+++ b/jRandomSkills - SRC Files/src/utils/SkillUtils.cs
@@ -524,7 +524,7 @@ namespace src.utils
                 ? $"<font class='fontWeight-Bold fontSize-{config.SkillLineSize}'>\u202A{Illiterate.GetRandomText(player.GetSkillName(skillData.Skill))}\u202C</font><br>"
                 : $"<font class='fontWeight-Bold fontSize-{config.SkillLineSize}' color='{skillData.Color}'>\u202A{player.GetSkillName(skillData.Skill)}\u202C</font><br>";
 
-            var skill_select_info = player.GetTranslation($"{playerInfo.Skill.ToString().ToLower()}_select_info");
+            var skill_select_info = player.GetTranslation($"{playerInfo.Skill.ToString().ToLowerInvariant()}_select_info");
             string remainingLine = string.IsNullOrWhiteSpace(skill_select_info)
                 ? ""
                 : $"<font class='fontSize-{config.WSADMenuSelectInfoLineSize}' color='{config.WSADMenuSelectInfoLineColor}'>{skill_select_info}</font><br>";
@@ -585,8 +585,8 @@ namespace src.utils
         {
             if (jRandomSkills.Instance == null || jRandomSkills.Instance.GameRules == null) return;
             var teams = Utilities.FindAllEntitiesByDesignerName<CCSTeam>("cs_team_manager");
-            var ctTeam = teams.First(t => t.IsValid && (CsTeam)t.TeamNum == CsTeam.CounterTerrorist);
-            var tTeams = teams.First(t => t.IsValid && (CsTeam)t.TeamNum == CsTeam.Terrorist);
+            var ctTeam = teams.FirstOrDefault(t => t.IsValid && (CsTeam)t.TeamNum == CsTeam.CounterTerrorist);
+            var tTeams = teams.FirstOrDefault(t => t.IsValid && (CsTeam)t.TeamNum == CsTeam.Terrorist);
             if (ctTeam == null || tTeams == null) return;
 
             short ctScore = (short)(winnerTeam == CsTeam.CounterTerrorist ? ctTeam.Score + 1 : ctTeam.Score);
@@ -686,8 +686,8 @@ namespace src.utils
         private static void UpdateClientTeamScores(MCCSMatch match)
         {
             var teams = Utilities.FindAllEntitiesByDesignerName<CCSTeam>("cs_team_manager");
-            var ctTeam = teams.First(t => t.IsValid && (CsTeam)t.TeamNum == CsTeam.CounterTerrorist);
-            var tTeams = teams.First(t => t.IsValid && (CsTeam)t.TeamNum == CsTeam.Terrorist);
+            var ctTeam = teams.FirstOrDefault(t => t.IsValid && (CsTeam)t.TeamNum == CsTeam.CounterTerrorist);
+            var tTeams = teams.FirstOrDefault(t => t.IsValid && (CsTeam)t.TeamNum == CsTeam.Terrorist);
 
             if (ctTeam != null && tTeams != null)
             {

--- a/jRandomSkills - SRC Files/src/utils/SkillsInfo.cs
+++ b/jRandomSkills - SRC Files/src/utils/SkillsInfo.cs
@@ -18,6 +18,10 @@ namespace src.utils
         private static SkillsInfoModel config = LoadSkillsInfo();
         public static SkillsInfoModel LoadedConfig => config;
 
+        private static SkillsInfoModel? _indexedConfig;
+        private static ConcurrentDictionary<string, DefaultSkillInfo> _byName = new();
+        private static readonly ConcurrentDictionary<(Type Type, string Key), MemberInfo?> _memberCache = new();
+
         public static SkillsInfoModel LoadSkillsInfo()
         {
             lock (fileLock)
@@ -84,26 +88,39 @@ namespace src.utils
         {
             if (config == null) return default!;
 
-            var skillConfig = LoadedConfig.FirstOrDefault(s => s.Name == skill.ToString());
-            if (skillConfig == null) return default!;
+            EnsureIndex();
+            if (!_byName.TryGetValue(skill.ToString()!, out var skillConfig) || skillConfig == null)
+                return default!;
 
-            var prop = skillConfig.GetType().GetProperty(key, BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
-            if (prop != null)
+            var member = _memberCache.GetOrAdd((skillConfig.GetType(), key), k =>
             {
-                var value = prop.GetValue(skillConfig);
-                if (value == null) return default!;
-                else return (T)Convert.ChangeType(value, typeof(T));
-            }
+                MemberInfo? m = k.Type.GetProperty(k.Key, BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
+                m ??= k.Type.GetField(k.Key, BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
+                return m;
+            });
 
-            var field = skillConfig.GetType().GetField(key, BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
-            if (field != null)
+            object? value = member switch
             {
-                var value = field.GetValue(skillConfig);
-                if (value == null) return default!;
-                else return (T)Convert.ChangeType(value, typeof(T));
-            }
+                PropertyInfo p => p.GetValue(skillConfig),
+                FieldInfo f => f.GetValue(skillConfig),
+                _ => null
+            };
 
-            return default!;
+            if (value == null) return default!;
+            return (T)Convert.ChangeType(value, typeof(T));
+        }
+
+        private static void EnsureIndex()
+        {
+            if (ReferenceEquals(_indexedConfig, config)) return;
+
+            var dict = new ConcurrentDictionary<string, DefaultSkillInfo>();
+            foreach (var s in config)
+                dict[s.Name] = s;
+
+            _byName = dict;
+            _indexedConfig = config;
+            _memberCache.Clear();
         }
 
         public class SkillsInfoModel : ConcurrentBag<DefaultSkillInfo>


### PR DESCRIPTION
- #### General:
    - ###### Fixed a bug where a player could be given multiple skills at once while the HUD displayed only one (the player list was never cleared on map change and had no duplicate protection on join).
    - ###### Fixed skill names and descriptions showing the raw translation key on Turkish servers (culture-sensitive lowercasing) - affected skills starting with "I" (e.g. Illiterate, Impostor, InfiniteAmmo, Iana).
    - ###### RayTrace-based skills and the skill-use button no longer throw when the RayTrace module is not installed - they now degrade gracefully instead of crashing.
    - ###### Fixed the skill-use button (when bound to Use/E) blocking option selection inside WSAD target menus.
    - ###### Performance: cached reflection lookups in `SkillAction` and `SkillsInfo.GetValue`, and de-duplicated the repeated event-dispatch logic on hot paths (OnTick, OnTakeDamage, etc.).
    - ###### Stability: removed dead methods that threw `NotImplementedException`, hardened team-score handling, and reset all skill state on round start / map change.
    - ###### Build: post-build copy paths now follow the active `$(Configuration)` and `$(TargetFramework)`.
    - ###### Added new Turkish translation strings for the skill notifications listed below.

- #### Skill improvements:
    - ###### Wallhack: - ###### Fixed enemy outlines briefly flashing for everyone when the skill holder dies.
    - ###### Area Reaper:
        - ###### Teammates (CT) are now notified which bombsite (A/B) was sealed.
    - ###### Wild Throw: - ###### Now notifies the targeted player, consistent with other targeted skills.
    - ###### Careful Bullets / Darkness / Deaf / Glitch / Jammer / Jump Ban / Magnifier / Poison / Primary Ban:
        - ###### The targeted player is now notified when the effect ends after the skill holder dies.